### PR TITLE
setup.py: fix installation under pip

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,8 @@ import os
 import sys
 from setuptools import setup, find_packages
 
-os.chdir(os.path.dirname(sys.argv[0]))
+if os.path.dirname(__file__) != "":
+    os.chdir(os.path.dirname(__file__))
 if not os.path.exists('pynlpl'):
     print("Preparing build",file=sys.stderr)
     if os.path.exists('build'):


### PR DESCRIPTION
pip installs pynlpl by invoking the setup.py without a fully specified path,
causing the chdir() invocation to fail with this message:

  Downloading PyNLPl-0.6.5.1.tar.gz (121kB): 121kB downloaded
  Running setup.py egg_info for package pynlpl
    Traceback (most recent call last):
      File "<string>", line 16, in <module>
      File "/tmp/pip_build_bazsi/pynlpl/setup.py", line 11, in <module>
        os.chdir(os.path.dirname(sys.argv[0]))
    OSError: [Errno 2] No such file or directory: ''
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):

  File "<string>", line 16, in <module>

  File "/tmp/pip_build_bazsi/pynlpl/setup.py", line 11, in <module>

```
os.chdir(os.path.dirname(sys.argv[0]))
```

The workaround is to tell pip not to clean up the sources and install
pynlpl manually. This fix solves the problem by not using
argv[0] that might lack a fully specified path, but rather using **file**,
that Python already fills nicely for us.

Signed-off-by: Balazs Scheidler bazsi@balabit.hu
