### PR TITLE
Fix comparison between integer and byte string (python3)

### DIFF
--- a/clients/frogclient.py
+++ b/clients/frogclient.py
@@ -55,7 +55,7 @@ class FrogClient:
         done = False
         while not done:
             data = b""
-            while not data or data[-1] != b'\n':
+            while not data.endswith(b'\n'):
                 moredata = self.socket.recv(self.BUFSIZE)
                 if not moredata: break
                 data += moredata


### PR DESCRIPTION
In python3, indexing a byte string yields an integer, which you can't compare to a non-indexed byte string, i.e.:

```{python}
>>> b"READY\n"[-1] == b"\n"
False
```
This caused the function to hang waiting for `moredata`, since the condition was never met.

The `endswith` works in both python2 and python3 and is also (imho) slightly more readable

(Note: running the tests locally caused a lot of errors unconnected to this change, so I hope travis agrees with this commit - Edit: Travis seems to build fine: https://travis-ci.org/vanatteveldt/pynlpl/builds/114657568)