### PR TITLE
Docs build: fix AttributeError tracebacks

### DIFF
--- a/docs/_templates/foliaelement.rst
+++ b/docs/_templates/foliaelement.rst
@@ -17,9 +17,11 @@
    {% for item in methods %}
       ~{{ name }}.{{ item }}
    {%- endfor %}
-    ~{{ name }}.__iter__
-    ~{{ name }}.__len__
-    ~{{ name }}.__str__
+    {% for private_method in ['__iter__', '__len__', '__str__'] %}
+    {% if private_method in members %}
+    ~{{ name }}.{{ private_method }}
+    {% endif %}
+    {% endfor %}
    {% endif %}
    {% endblock %}
 
@@ -39,9 +41,8 @@
    {% for m in methods %}
    .. automethod:: {{ m }}
    {% endfor %}
-   .. automethod::  __iter__
-   .. automethod::  __len__
-   .. automethod::  __str__
-
-
-
+   {% for private_method in ['__iter__', '__len__', '__str__'] %}
+   {% if private_method in members %}
+   .. automethod:: {{ private_method }}
+   {% endif %}
+   {% endfor %}


### PR DESCRIPTION
Fixes the following tracebacks when building docs:
```
/builddir/build/BUILD/pynlpl-1.0.9/docs/_autosummary/pynlpl.formats.folia.AllowTokenAnnotation.rst:42: WARNING: autodoc: failed to import method u'AllowTokenAnnotation.__iter__' from module u'pynlpl.formats.folia'; the following exception was raised:
Traceback (most recent call last):
  File "/usr/lib/python2.7/site-packages/sphinx/ext/autodoc.py", line 526, in import_object
    obj = self.get_attr(obj, part)
  File "/usr/lib/python2.7/site-packages/sphinx/ext/autodoc.py", line 422, in get_attr
    return safe_getattr(obj, name, *defargs)
  File "/usr/lib/python2.7/site-packages/sphinx/util/inspect.py", line 125, in safe_getattr
    raise AttributeError(name)
AttributeError: __iter__
/builddir/build/BUILD/pynlpl-1.0.9/docs/_autosummary/pynlpl.formats.folia.AllowTokenAnnotation.rst:43: WARNING: autodoc: failed to import method u'AllowTokenAnnotation.__len__' from module u'pynlpl.formats.folia'; the following exception was raised:
Traceback (most recent call last):
  File "/usr/lib/python2.7/site-packages/sphinx/ext/autodoc.py", line 526, in import_object
    obj = self.get_attr(obj, part)
  File "/usr/lib/python2.7/site-packages/sphinx/ext/autodoc.py", line 422, in get_attr
    return safe_getattr(obj, name, *defargs)
  File "/usr/lib/python2.7/site-packages/sphinx/util/inspect.py", line 125, in safe_getattr
    raise AttributeError(name)
AttributeError: __len__
```