### PR TITLE
Docs build: fix sphinx build warnings

### DIFF
--- a/docs/textprocessors.rst
+++ b/docs/textprocessors.rst
@@ -8,7 +8,7 @@ This module contains classes and functions for text processing. It is imported a
 Tokenisation
 ------------------
 
-A very crude tokeniser is available in the form of the function ``pynlpl.textprocessors.crude_tokeniser(string)''. This will split punctuation characters from words and returns a list of tokens. It however has no regard for abbreviations and end-of-sentence detection, which is functionality a more sophisticated tokeniser can provide::
+A very crude tokeniser is available in the form of the function ``pynlpl.textprocessors.crude_tokeniser(string)``. This will split punctuation characters from words and returns a list of tokens. It however has no regard for abbreviations and end-of-sentence detection, which is functionality a more sophisticated tokeniser can provide::
 
 	tokens = pynlpl.textprocessors.crude_tokeniser("to be, or not to be.")
 	

--- a/formats/folia.py
+++ b/formats/folia.py
@@ -597,11 +597,12 @@ class AbstractElement(object):
         isinstance(x, AbstractElement)
 
     Generic FoLiA attributes can be accessed on all instances derived from this class:
+
     * ``element.id``        (str) - The unique identifier of the element
     * ``element.set``       (str) - The set the element pertains to.
-    * ``element.cls``       (str) - The assigned class, i.e. the actual value of
-        the annotation, defined in the set.  Classes correspond with tagsets in this case of many annotation types.
-        Note that since *class* is already a reserved keyword in python, the library consistently uses ``cls`` everywhere.
+    * ``element.cls``       (str) - The assigned class, i.e. the actual value of \
+    the annotation, defined in the set.  Classes correspond with tagsets in this case of many annotation types. \
+    Note that since *class* is already a reserved keyword in python, the library consistently uses ``cls`` everywhere.
     * ``element.annotator`` (str) - The name or ID of the annotator who added/modified this element
     * ``element.annotatortype`` - The type of annotator, can be either ``folia.AnnotatorType.MANUAL`` or ``folia.AnnotatorType.AUTO``
     * ``element.confidence`` (float) - A confidence value expressing
@@ -2357,7 +2358,7 @@ class AbstractElement(object):
         """Internal class method used for turning an XML element into an instance of the Class.
 
         Args:
-            * ``node`' - XML Element
+            * ``node`` - XML Element
             * ``doc`` - Document
 
         Returns:
@@ -3191,6 +3192,7 @@ class TextContent(AbstractElement):
     on structure elements like :class:`Paragraph` and :class:`Sentence` are by definition untokenised. Only on :class:`Word`` level and deeper they are by definition tokenised.
 
     Text content elements can specify offset that refer to text at a higher parent level. Use the following keyword arguments:
+
         * ``ref=``: The instance to point to, this points to the element holding the text content element, not the text content element itself.
         * ``offset=``: The offset where this text is found, offsets start at 0
     """
@@ -3405,9 +3407,10 @@ class TextContent(AbstractElement):
 class PhonContent(AbstractElement):
     """Phonetic content element (``ph``), holds a phonetic representation to be associated with whatever element the phonetic content element is a child of.
 
-    Phonetic content elements behave much like text content elements
+    Phonetic content elements behave much like text content elements.
 
     Phonetic content elements can specify offset that refer to phonetic content at a higher parent level. Use the following keyword arguments:
+
         * ``ref=``: The instance to point to, this points to the element holding the text content element, not the text content element itself.
         * ``offset=``: The offset where this text is found, offsets start at 0
     """
@@ -4827,7 +4830,7 @@ class Correction(AbstractElement, AllowGenerateID):
         """Get suggestions for correction.
 
         Yields:
-            :class:`Suggestion` element that encapsulate the suggested annotations (if index is ``None`, default)
+            :class:`Suggestion` element that encapsulate the suggested annotations (if index is ``None``, default)
 
         Returns:
             a :class:`Suggestion` element that encapsulate the suggested annotations (if index is set)


### PR DESCRIPTION
There are a number of warnings messages when building documentation.
This pull request will fix most of them and can be used as a starting point to fix the rest.